### PR TITLE
Update Adult Weir Query and Water Temp Import

### DIFF
--- a/DataTracker/index.html
+++ b/DataTracker/index.html
@@ -4,6 +4,7 @@
     <title>Dataset Tracker v.1.0</title>
 
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta http-equiv="Cache-Control" content="no-cache, no-store">
     <link href='//fonts.googleapis.com/css?family=Lusitana' rel='stylesheet' type='text/css'>
     <link rel="stylesheet" href="../assets/js/vendor/select2/select2.css"/>    
     <link rel="stylesheet" href="//netdna.bootstrapcdn.com/bootstrap/3.0.3/css/bootstrap.min.css"/>

--- a/DataTracker/js/controllers/dataedit-controllers.js
+++ b/DataTracker/js/controllers/dataedit-controllers.js
@@ -339,7 +339,7 @@ mod_edit.controller('DataEditCtrl', ['$scope','$q','$sce','$routeParams','DataSe
 		
 		//update our location options as soon as our project is loaded.
         $scope.$watch('project.Name', function(){
-        	if(!$scope.project) return;
+        	if(!$scope.project.Name) return;
 			
 			console.log("Inside watcher, project.Name...");
 			console.log("$scope is next...");

--- a/DataTracker/js/controllers/dataentry-controllers.js
+++ b/DataTracker/js/controllers/dataentry-controllers.js
@@ -1557,6 +1557,7 @@ mod_de.controller('DataEntryFormCtrl', ['$scope','$routeParams','DataService','$
 			var strYear = null;
 			var strMonth = null;
 			var strDay = null;
+			var tmpTime = null;
 			
 			/**** CreeSurvey Detail Time Time calculations Start ****/
 			if ($scope.DatastoreTablePrefix === "CreelSurvey")
@@ -1589,7 +1590,7 @@ mod_de.controller('DataEntryFormCtrl', ['$scope','$routeParams','DataService','$
 						$scope.dataSheetDataset[i].TotalTimeFished = TotalTimeFished;
 					}
 					
-					if ((typeof $scope.dataSheetDataset[i].InterviewTime !== 'undefined') && ($scope.dataSheetDataset[i].InterviewTime != null))
+					if ((typeof $scope.dataSheetDataset[i].InterviewTime !== 'undefined') && ($scope.dataSheetDataset[i].InterviewTime !== null))
 					{
 						tmpTime = $scope.dataSheetDataset[i].InterviewTime;
 						//console.log("tmpTime (TimeEnd) = " + tmpTime);

--- a/DataTracker/js/controllers/dataentry-controllers.js
+++ b/DataTracker/js/controllers/dataentry-controllers.js
@@ -121,7 +121,7 @@ mod_de.controller('DataEntryDatasheetCtrl', ['$scope','$routeParams','DataServic
 		
 		//update our location options as soon as our project is loaded.
         $scope.$watch('project.Name', function(){
-        	if(!$scope.project) return;
+        	if(!$scope.project.Name) return;
 			
 			console.log("Inside watch project.Name...");
 			//console.log("$scope.project is next...");

--- a/DataTracker/js/controllers/dataentry-controllers.js
+++ b/DataTracker/js/controllers/dataentry-controllers.js
@@ -124,7 +124,7 @@ mod_de.controller('DataEntryDatasheetCtrl', ['$scope','$routeParams','DataServic
         	if(!$scope.project) return;
 			
 			console.log("Inside watch project.Name...");
-			//console.log($scope.project is next...");
+			//console.log("$scope.project is next...");
         	//console.dir($scope.project);
 			
 			$rootScope.projectId = $scope.project.Id;
@@ -720,10 +720,11 @@ mod_de.controller('DataEntryFormCtrl', ['$scope','$routeParams','DataService','$
         //update our location options as soon as our project is loaded.
 		// The project gets called/loaded in $scope.$watch('dataset.Fields' (above), so $scope.DatastoreTablePrefix was set there.
         $scope.$watch('project.Name', function(){
-        	if(!$scope.project) return;
-        	//console.dir($scope.project);
+        	if(!$scope.project.Name) return;
 			
 			console.log("Inside watch project.Name...");
+			//console.log("$scope.project is next...");
+        	//console.dir($scope.project);
 			
 			$rootScope.projectId = $scope.project.Id;
 			$scope.project.Files = null;

--- a/DataTracker/js/controllers/dataquery-controllers.js
+++ b/DataTracker/js/controllers/dataquery-controllers.js
@@ -239,9 +239,10 @@ mod_dq.controller('DataQueryCtrl', ['$scope','$routeParams','DataService','$loca
 				}
 				else if ($scope.DatastoreTablePrefix === "AdultWeir") 
 				{
-					$scope.showActivitiesWhereAll = false;
+					//$scope.showActivitiesWhereAll = false;
+					$scope.showActivitiesWhereAll = true;
 					$scope.showActivitiesWhereRunYear = true;
-					$scope.Criteria.paramActivityDateType = "singleYear";
+					//$scope.Criteria.paramActivityDateType = "singleYear"; // We set this in BuildQuery instead.
 					$scope.runYearsList = DataService.getRunYears($scope.dataset.Id);
 				}
 				else if ($scope.DatastoreTablePrefix === "ScrewTrap") 
@@ -556,6 +557,13 @@ mod_dq.controller('DataQueryCtrl', ['$scope','$routeParams','DataService','$loca
 						Year:	yearRec["RunYear"]
 					});
 				});
+				if ($scope.RowRunYears.length > 0)
+				{
+					$scope.RowRunYears.push({
+						Id:		["0"],
+						Year:	[null]
+					});
+				}
 				console.log("$scope.RowRunYears is next...");
 				console.dir($scope.RowRunYears);
 				$scope.RunYearOptions = makeObjects($scope.RowRunYears, 'Id', 'Year');
@@ -729,9 +737,16 @@ mod_dq.controller('DataQueryCtrl', ['$scope','$routeParams','DataService','$loca
 					loading: true,
 				};
 				
+				//if ($scope.DatastoreTablePrefix === "AdultWeir")
 				if ($scope.DatastoreTablePrefix === "AdultWeir")
 				{
-					query.criteria.RunYear = $scope.Criteria.paramActivityWhereRunYear;
+					if (($scope.Criteria.paramActivityWhereRunYear) && ($scope.Criteria.paramActivityWhereRunYear > 0))
+					{
+						query.criteria.DateSearchType = $scope.Criteria.paramActivityDateType = "singleYear";
+						query.criteria.RunYear = $scope.Criteria.paramActivityWhereRunYear;
+					}
+					else
+						query.criteria.DateSearchType = $scope.Criteria.paramActivityDateType;
 				}
 				else if ($scope.DatastoreTablePrefix === "ScrewTrap")
 				{

--- a/DataTracker/js/controllers/dataquery-controllers.js
+++ b/DataTracker/js/controllers/dataquery-controllers.js
@@ -373,7 +373,7 @@ mod_dq.controller('DataQueryCtrl', ['$scope','$routeParams','DataService','$loca
 	    	});
 								
     		$scope.$watch('project.Name', function(){
-    			if($scope.project){	
+    			if($scope.project.Name){	
 					console.log("Inside DataQueryCtrl, project.Name watcher...");
 					
 					// Original code

--- a/DataTracker/js/controllers/dataquery-controllers.js
+++ b/DataTracker/js/controllers/dataquery-controllers.js
@@ -252,9 +252,9 @@ mod_dq.controller('DataQueryCtrl', ['$scope','$routeParams','DataService','$loca
 					$scope.migrationYearsList = DataService.getMigrationYears($scope.dataset.Id);
 				}
 				//else if ($scope.DatastoreTablePrefix === "Metrics")
-				else if ((scope.datasets[i].Datastore.TablePrefix === "Metrics") || 
-					(scope.datasets[i].Datastore.TablePrefix === "Benthic") ||
-					(scope.datasets[i].Datastore.TablePrefix === "Drift")
+				else if (($scope.DatastoreTablePrefix === "Metrics") || 
+					($scope.DatastoreTablePrefix === "Benthic") ||
+					($scope.DatastoreTablePrefix === "Drift")
 					)
 				{
 					$scope.showActivitiesWhereAll = false;

--- a/DataTracker/js/controllers/import-controllers.js
+++ b/DataTracker/js/controllers/import-controllers.js
@@ -304,7 +304,7 @@ mod_di.controller("DatasetImportCtrl", ['$scope','$routeParams','DatastoreServic
     		});
 			
 			$scope.$watch('project.Name', function(){
-	        	if(!$scope.project) return;
+	        	if(!$scope.project.Name) return;
 				
 				console.log("Inside DatasetImportCtrl, project.Name watcher...");
 	        	//Logger.debug($scope.project);

--- a/DataTracker/js/controllers/import-controllers.js
+++ b/DataTracker/js/controllers/import-controllers.js
@@ -1429,11 +1429,13 @@ mod_di.controller("DatasetImportCtrl", ['$scope','$routeParams','DatastoreServic
 						angular.forEach($scope.mapping, function(field, col){
 							//console.log("field = " + field + ", col = " + col);
 							//var value = row[field.DbColumnName];
-							//if (typeof field.DbColumnName !== 'undefined')
-							//{
-							//	var value = row[field.DbColumnName];
+							var value = null;
+							if (typeof field.DbColumnName !== 'undefined')
+							{
+								//var value = row[field.DbColumnName];
+								value = row[field.DbColumnName];								
 								//console.log("field.DbColumnName = " + field.DbColumnName + "; value = " + value); // Debug step
-							//}
+							}
 
 							if (($scope.DatastoreTablePrefix === "ScrewTrap") && (field.DbColumnName === "TextualComments"))
 							{
@@ -1490,6 +1492,8 @@ mod_di.controller("DatasetImportCtrl", ['$scope','$routeParams','DatastoreServic
 
 							try{
 								//fire Field rule if it exists -- OnChange
+								//console.log("field is next...");
+								//console.dir(field);
 								if(field.Field && field.Field.Rule && field.Field.Rule.OnChange){
 									//console.log("Firing master rule: " + field.Field.Rule.OnChange);
 									eval(field.Field.Rule.OnChange);

--- a/DataTracker/js/index.html
+++ b/DataTracker/js/index.html
@@ -4,6 +4,7 @@
   <title>Just a map test</title>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
   <meta name="viewport" content="initial-scale=1, maximum-scale=1,user-scalable=no">
+  <meta http-equiv="Cache-Control" content="no-cache, no-store">
   <link rel="stylesheet" href="http://js.arcgis.com/3.9/js/dojo/dijit/themes/claro/claro.css">
   <link rel="stylesheet" href="http://js.arcgis.com/3.9/js/esri/css/esri.css">
   <style>

--- a/DataTracker/login.html
+++ b/DataTracker/login.html
@@ -4,6 +4,7 @@
     <title>Dataset Tracker v.1.0</title>
 
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta http-equiv="Cache-Control" content="no-cache, no-store">
     <link href='//fonts.googleapis.com/css?family=Lusitana' rel='stylesheet' type='text/css'>
     <link rel="stylesheet" href="//netdna.bootstrapcdn.com/bootstrap/3.0.3/css/bootstrap.min.css"/>
 

--- a/index.htm
+++ b/index.htm
@@ -1,5 +1,6 @@
 <html>
 <head>
 	<meta http-equiv="refresh" content="0; url=DataTracker/index.html" />
+	<meta http-equiv="Cache-Control" content="no-cache, no-store">
 </head>
 </html>


### PR DESCRIPTION
This release includes the following fixes.

(AdultWeirQueryFix) When a user added an Activity with a header but no details, and then ran a query (Dataset Query page), the new record would not show.  This issue was due to the Run Year being a Detail item.  The top-level database view only pulled Activities that had both header and details.  This update includes a database change to AdultWeir_vw, changing the inner join for the Details to a LEFT OUTER JOIN.  This update also allows the user to query by Activity Dates, rather than just by the Run Year.

(WaterTempImport) If a user imported an Activity that had temperature values in degree C, or degrees F, but not both, the app was supposed to automatically convert and supply the missing value.  For example, if only C came in, then the system would convert to F and store that value also.  A variable involved with that procedure was turned off, causing the process not to work.  This update turned that variable back on, so that the process works again.

(projectWatchFix)  When a user was the owner of a project, the system would not authorize that user to add records.  This was a timing issue in the project watch.  Revised what variable the watch observes.

(burpScanFix)  Improved web page security.
