### PR TITLE
Crpp contracts

### DIFF
--- a/app/private/crpp/components/crpp-contracts/modal-create-crpp-subproject.js
+++ b/app/private/crpp/components/crpp-contracts/modal-create-crpp-subproject.js
@@ -16,7 +16,7 @@ var modal_create_crpp_subproject = ['$scope', '$rootScope', '$modalInstance', 'D
             //OwningDepartmentId: 1,
         };
 		//$scope.subproject_row.strCounties = "";
-		$scope.subproject_row.County = [];
+		//$scope.subproject_row.County = [];
 
         $scope.agencyList = [];
         $scope.agencyList.push({ Id: 0, Label: "ACHP" });

--- a/app/private/crpp/components/crpp-contracts/tab-correspondence.js
+++ b/app/private/crpp/components/crpp-contracts/tab-correspondence.js
@@ -159,9 +159,9 @@ var tab_correspondence = ['$scope', '$timeout', 'SubprojectService', 'ProjectSer
             },
             { field: 'TrackingNumber', headerName: 'Tracking #', width: 100, menuTabs: ['filterMenuTab'], },
             { field: 'Agency', headerName: 'Agency', cellRenderer: otherAgencyTemplate, width: 150, menuTabs: ['filterMenuTab'], },
-            { field: 'County', headerName: 'County', width: 150, menuTabs: ['filterMenuTab'], },
+            //{ field: 'County', headerName: 'County', width: 150, menuTabs: ['filterMenuTab'], },
+            { field: 'strCounties', headerName: 'County', width: 150, menuTabs: ['filterMenuTab'], },
             { field: 'ProjectProponent', headerName: 'Project Proponent', width: 150, menuTabs: ['filterMenuTab'], },
-
 
         ];
 


### PR DESCRIPTION
This update does the following.
- Allows the County to be blank
- If/when a user deletes a CRPP Subproject, the system now also cleans up after itself, by deleting the Subproject’s associated Counties in tbl Counties; the records were being orphaned
