### PR TITLE
Hide Map button on Fish Scale datasets.

### DIFF
--- a/app/core/datasets/components/dataset-activities-list/templates/dataset-activities.html
+++ b/app/core/datasets/components/dataset-activities-list/templates/dataset-activities.html
@@ -26,7 +26,8 @@
 <div class="container-fluid">
     <div class="row-fluid">
         <div class="span2">
-            <button style="margin-bottom: 15px;" type="button" ng-click="toggleMap()">{{ShowMap.Message}} <span ng-show="!ShowMap.Display" class="glyphicon glyphicon-circle-arrow-right"></span><span ng-show="ShowMap.Display" class="glyphicon glyphicon-circle-arrow-down"></span></button>
+            <!--<button style="margin-bottom: 15px;" type="button" ng-click="toggleMap()">{{ShowMap.Message}} <span ng-show="!ShowMap.Display" class="glyphicon glyphicon-circle-arrow-right"></span><span ng-show="ShowMap.Display" class="glyphicon glyphicon-circle-arrow-down"></span></button>-->
+            <button ng-hide="dataset.Config && dataset.Config.ActivitiesPage.HiddenFields.contains('MapButton')" style="margin-bottom: 15px;" type="button" ng-click="toggleMap()">{{ShowMap.Message}} <span ng-show="!ShowMap.Display" class="glyphicon glyphicon-circle-arrow-right"></span><span ng-show="ShowMap.Display" class="glyphicon glyphicon-circle-arrow-down"></span></button>
             <!-- img class="map-center" src="assets/images/map_image1.png"  -->
             <div ng-show="ShowMap.Display">
                 <div style="margin-left:125px; margin-top: -45px; margin-bottom: 25px;" id="basemapDropdown">


### PR DESCRIPTION
This update turns the Map button off, on the Dataset Activities page, for all Fish Scales datasets, but leaves it on for all others.