### PR TITLE
Add Instrument Duplicate Fix

### DIFF
--- a/app/core/common/components/modals/modal-create-instrument.js
+++ b/app/core/common/components/modals/modal-create-instrument.js
@@ -1,5 +1,5 @@
 ﻿var modal_create_instrument = ['$scope', '$modalInstance', 'DatasetService', 'ProjectService', 'CommonService',
-    function ($scope, $modalInstance, DatasetService, ProjectService, CommonService){
+    function ($scope, $modalInstance, DatasetService, ProjectService, CommonService) {
 
     $scope.header_message = "Create new instrument";
 
@@ -18,15 +18,23 @@
     $scope.InstrumentTypes = ProjectService.getInstrumentTypes();
     $scope.Departments = CommonService.getDepartments();
     $scope.RawProjects = ProjectService.getProjects();
+    $scope.instrumentList = ProjectService.getInstruments();
 
 
     $scope.save = function(){
-		console.log("Inside ModalCreateInstrumentCtrl, save...");
-		if (!$scope.instrument_row.InstrumentTypeId)
-		{
-			alert("You must select an Instrument Type!");
-			return;
-		}
+        console.log("Inside modal_create_instrument, save...");
+        console.log("$scope.instrument_row is next...");
+        console.dir($scope.instrument_row);
+        console.dir($scope);
+
+        if (!$scope.instrument_row.InstrumentTypeId) {
+            alert("You must select an Instrument Type!");
+            return;
+        }
+        else if (CommonService.checkForDuplicateInstrument($scope.instrumentList, $scope.instrument_row)) {
+            alert("An instrument with this name and serial number has already been entered!");
+            return;
+        }
 		
         var saveRow = angular.copy($scope.instrument_row);
 		console.log("saveRow is next...");

--- a/app/core/common/services/common-service.js
+++ b/app/core/common/services/common-service.js
@@ -57,7 +57,6 @@ common_module.factory('GetLocationTypes', ['$resource', function ($resource) {
     return $resource(serviceUrl + '/api/v1/location/getlocationtypes');
 }]);
 
-
 common_module.service('CommonService', ['$q',
     'GetMetadataProperties',
     'SaveDatasetMetadata',
@@ -238,6 +237,27 @@ common_module.service('CommonService', ['$q',
                 });
 
                 return newInstrumentList;
+            },
+
+            checkForDuplicateInstrument: function (instrumentList, instrument) {
+                var blnInstrumentExists = false;
+                var blnKeepGoing = true;
+
+                angular.forEach(instrumentList, function (item) {
+                    // Have we found a match yet? If so, we do not need to check the rest of the items.
+                    if (blnKeepGoing) {
+                        if ((item.Name === instrument.Name) && (item.SerialNumber === instrument.SerialNumber)) {
+                            blnInstrumentExists = true;
+                            blnKeepGoing = false;
+                        }
+                    }
+                });
+
+                return blnInstrumentExists;
+            },
+
+            getAllInstruments: function () {
+                return GetAllInstruments.query();
             },
 
             getMetadataProperty: function (propertyId) {

--- a/app/core/datasets/components/dataset-entry-form/dataset-entry-form.js
+++ b/app/core/datasets/components/dataset-entry-form/dataset-entry-form.js
@@ -795,9 +795,13 @@ var dataset_entry_form = ['$scope', '$routeParams',
             $scope.duplicateEntry = undefined;
             $scope.saving = true;
 
-			if (($scope.DatastoreTablePrefix === "CrppContracts") || ($scope.DatastoreTablePrefix === "WaterQuality"))
+			//if (($scope.DatastoreTablePrefix === "CrppContracts") || ($scope.DatastoreTablePrefix === "WaterQuality"))
+            if (($scope.DatastoreTablePrefix === "CrppContracts") ||
+                ($scope.DatastoreTablePrefix === "WaterQuality") ||
+                ($scope.DatastoreTablePrefix.indexOf("StreamNet_") > -1)
+                )
 			{
-				console.log("This dataset is either CrppContracts or WaterQuality, not checking for duplicates.");
+				console.log("This dataset is not checked for duplicates.");
 				$scope.duplicateEntry = false;
 				$scope.activities.errors = undefined;
 				//$scope.continueSaving();

--- a/app/core/datasets/components/dataset-entry-form/dataset-entry-form.js
+++ b/app/core/datasets/components/dataset-entry-form/dataset-entry-form.js
@@ -505,7 +505,11 @@ var dataset_entry_form = ['$scope', '$routeParams',
             if ($scope.row.LastAccuracyCheck)
                 $scope.row.AccuracyCheckId = $scope.row.LastAccuracyCheck.Id;
 			
-			if (($scope.DatastoreTablePrefix !== "CrppContracts") && ($scope.DatastoreTablePrefix !== "WaterQuality"))
+			//if (($scope.DatastoreTablePrefix !== "CrppContracts") && ($scope.DatastoreTablePrefix !== "WaterQuality"))
+            if (($scope.DatastoreTablePrefix !== "CrppContracts") &&
+                ($scope.DatastoreTablePrefix !== "WaterQuality") &&
+                ($scope.DatastoreTablePrefix.indexOf("StreamNet_") < 0)
+            )
 			{
 				$scope.activities.errors = undefined;
 				$scope.removeRowErrorsBeforeRecheck();
@@ -1339,7 +1343,11 @@ var dataset_entry_form = ['$scope', '$routeParams',
 
 			console.log("New location selected = " + $scope.locationOptions[$scope.row.locationId]);
 			
-			if (($scope.DatastoreTablePrefix !== "CrppContracts") && ($scope.DatastoreTablePrefix !== "WaterQuality"))
+			//if (($scope.DatastoreTablePrefix !== "CrppContracts") && ($scope.DatastoreTablePrefix !== "WaterQuality"))
+            if (($scope.DatastoreTablePrefix !== "CrppContracts") &&
+                ($scope.DatastoreTablePrefix !== "WaterQuality") &&
+                ($scope.DatastoreTablePrefix.indexOf("StreamNet_") < 0)
+            )
 			{
 				//$scope.activities.errors = {};
 				$scope.activities.errors = undefined;
@@ -1352,11 +1360,17 @@ var dataset_entry_form = ['$scope', '$routeParams',
 		$scope.onActivityDateChange = function()
 		{
 			console.log("Inside $scope.onActivityDateChange...");
-			
-			//$scope.activities.errors = {};
-			$scope.activities.errors = undefined;
-			$scope.duplicateEntry = undefined;
-			$scope.checkForDuplicates();
+
+            if (($scope.DatastoreTablePrefix !== "CrppContracts") &&
+                ($scope.DatastoreTablePrefix !== "WaterQuality") &&
+                ($scope.DatastoreTablePrefix.indexOf("StreamNet_") < 0)
+            )
+            {
+                //$scope.activities.errors = {};
+                $scope.activities.errors = undefined;
+                $scope.duplicateEntry = undefined;
+                $scope.checkForDuplicates();
+            }
 		};
 		
 		$scope.rebuildDateTimeList = function()

--- a/app/core/datasets/components/dataset-import/dataset-import.js
+++ b/app/core/datasets/components/dataset-import/dataset-import.js
@@ -1716,7 +1716,11 @@
 				console.log("$scope.dataSheetDataset is nextX...");
 				console.dir($scope.dataSheetDataset);
 				//throw "Stopping right here.";
-				if (($scope.DatastoreTablePrefix !== "CrppContracts") && ($scope.DatastoreTablePrefix !== "WaterQuality"))
+                //if (($scope.DatastoreTablePrefix !== "CrppContracts") && ($scope.DatastoreTablePrefix !== "WaterQuality"))
+                if (($scope.DatastoreTablePrefix !== "CrppContracts") &&
+                    ($scope.DatastoreTablePrefix !== "WaterQuality") &&
+                    ($scope.DatastoreTablePrefix.indexOf("StreamNet_") < 0)
+                    )
 				{
 					$scope.checkForDuplicates();
 				}

--- a/app/core/datasets/components/dataset-import/dataset-import.js
+++ b/app/core/datasets/components/dataset-import/dataset-import.js
@@ -1726,7 +1726,7 @@
 				}
 				else
 				{
-					console.log("This dataset is either CrppContracts or WaterQuality, not checking for duplicates.");
+					console.log("This dataset is not checked for duplicates.");
 					$scope.DupeCheckRunning = false;
 					$scope.duplicateEntry = false;
 					$scope.weHaveDuplicates = false;


### PR DESCRIPTION
This update includes the following.
-Dataset Import, Preview page, when adding a new instrument, it will not save; fixed
-Project, Instruments tab, should not allow user to enter duplicate; fixed
-Excluded StreamNet datasets from duplicate checking